### PR TITLE
Fix Airtable field name issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ that directory. The available workflows are:
 
 All workflows directly loop over their respective folders; there is no separate
 templates directory anymore.
+
+## Environment Variables
+
+Scripts rely on the following environment variables when run through the
+workflows:
+
+* `AIRTABLE_API_KEY` – API key with access to the target Airtable base.
+* `GH_TOKEN` – GitHub token used for uploading intermediate files.
+* `AIRTABLE_ATTACHMENT_FIELD` – *(optional)* name of the Airtable field that
+  stores uploaded files. If not provided, the utilities default to a field
+  named `Attachments`.

--- a/code/daily/data_upload_utils.py
+++ b/code/daily/data_upload_utils.py
@@ -2,6 +2,10 @@ import os
 import base64
 import requests
 
+# The Airtable field used to store uploaded files. Override with the
+# AIRTABLE_ATTACHMENT_FIELD environment variable if needed.
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +49,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +71,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/data_upload_utils.py
+++ b/code/data_upload_utils.py
@@ -2,6 +2,11 @@ import os
 import base64
 import requests
 
+# Name of the Airtable attachment field. Can be overridden using the
+# AIRTABLE_ATTACHMENT_FIELD environment variable if a different field name is
+# configured in the Airtable base.
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +50,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +72,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/event_driven/data_upload_utils.py
+++ b/code/event_driven/data_upload_utils.py
@@ -2,6 +2,9 @@ import os
 import base64
 import requests
 
+# Attachment field for event-driven scripts
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +48,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +70,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/intraday/data_upload_utils.py
+++ b/code/intraday/data_upload_utils.py
@@ -2,6 +2,10 @@ import os
 import base64
 import requests
 
+# Allows overriding the Airtable attachment field name if it differs from the
+# previous hard-coded value. Defaults to the common "Attachments" field.
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +49,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +71,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/monthly/data_upload_utils.py
+++ b/code/monthly/data_upload_utils.py
@@ -2,6 +2,9 @@ import os
 import base64
 import requests
 
+# Field name used for Airtable attachments
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +48,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +70,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/quarterly/data_upload_utils.py
+++ b/code/quarterly/data_upload_utils.py
@@ -2,6 +2,9 @@ import os
 import base64
 import requests
 
+# Default Airtable attachment field name
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +48,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +70,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/weekly/data_upload_utils.py
+++ b/code/weekly/data_upload_utils.py
@@ -2,6 +2,9 @@ import os
 import base64
 import requests
 
+# Field storing attachments in Airtable
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +48,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +70,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]

--- a/code/yearly/data_upload_utils.py
+++ b/code/yearly/data_upload_utils.py
@@ -2,6 +2,9 @@ import os
 import base64
 import requests
 
+# Name of the attachment field in Airtable
+ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
+
 def upload_to_github(filename, repo_name, branch, upload_path, token):
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
@@ -45,7 +48,7 @@ def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     }
     patch_payload = {
         "fields": {
-            "Database Attachment": [
+            ATTACHMENT_FIELD: [
                 {
                     "url": raw_url,
                     "filename": filename
@@ -67,7 +70,7 @@ def create_airtable_record(name, raw_url, filename, airtable_url, airtable_token
     # Core required fields
     record_fields = {
         "Name": name,
-        "Database Attachment": [{
+        ATTACHMENT_FIELD: [{
             "url": raw_url,
             "filename": filename
         }]


### PR DESCRIPTION
## Summary
- allow configuring the Airtable attachment field name via `AIRTABLE_ATTACHMENT_FIELD`
- document new environment variable

## Testing
- `python -m py_compile $(find code -name '*.py' -print)`