### PR TITLE
Fix GitHub upload conflicts

### DIFF
--- a/code/daily/data_upload_utils.py
+++ b/code/daily/data_upload_utils.py
@@ -6,7 +6,9 @@ import requests
 # AIRTABLE_ATTACHMENT_FIELD environment variable if needed.
 ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
 
-def upload_to_github(filename, repo_name, branch, upload_path, token):
+def upload_to_github(filename, repo_name, branch, upload_path, token, max_retries=3):
+    """Upload a file to GitHub, retrying on 409 conflicts."""
+
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
 
@@ -16,31 +18,34 @@ def upload_to_github(filename, repo_name, branch, upload_path, token):
         "Accept": "application/vnd.github+json"
     }
 
-    # Step 1: Check if file already exists to get its SHA
-    get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
-    sha = None
-    if get_resp.status_code == 200:
-        sha = get_resp.json().get("sha")
+    for attempt in range(max_retries):
+        # Step 1: Check if file already exists to get its SHA
+        get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
+        sha = get_resp.json().get("sha") if get_resp.status_code == 200 else None
 
-    # Step 2: Prepare upload payload
-    upload_payload = {
-        "message": f"Upload {filename}",
-        "content": content,
-        "branch": branch
-    }
-    if sha:
-        upload_payload["sha"] = sha  # Needed for overwrite
+        # Step 2: Prepare upload payload
+        upload_payload = {
+            "message": f"Upload {filename}",
+            "content": content,
+            "branch": branch
+        }
+        if sha:
+            upload_payload["sha"] = sha  # Needed for overwrite
 
-    # Step 3: Upload (PUT) to GitHub
-    upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
-    if upload_resp.status_code not in [200, 201]:
+        # Step 3: Upload (PUT) to GitHub
+        upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
+        if upload_resp.status_code in [200, 201]:
+            # Step 4: Add raw_url manually
+            response_json = upload_resp.json()
+            raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
+            response_json['content']['raw_url'] = raw_url
+            return response_json
+
+        if upload_resp.status_code == 409 and attempt < max_retries - 1:
+            # Branch moved; retry after fetching the latest SHA
+            continue
+
         raise Exception(f"❌ GitHub upload failed: {upload_resp.status_code} - {upload_resp.text}")
-
-    # Step 4: Add raw_url manually
-    response_json = upload_resp.json()
-    raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
-    response_json['content']['raw_url'] = raw_url
-    return response_json
 
 def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     airtable_headers = {

--- a/code/data_upload_utils.py
+++ b/code/data_upload_utils.py
@@ -7,7 +7,9 @@ import requests
 # configured in the Airtable base.
 ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
 
-def upload_to_github(filename, repo_name, branch, upload_path, token):
+def upload_to_github(filename, repo_name, branch, upload_path, token, max_retries=3):
+    """Upload a file to GitHub, retrying on 409 conflicts."""
+
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
 
@@ -17,31 +19,34 @@ def upload_to_github(filename, repo_name, branch, upload_path, token):
         "Accept": "application/vnd.github+json"
     }
 
-    # Step 1: Check if file already exists to get its SHA
-    get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
-    sha = None
-    if get_resp.status_code == 200:
-        sha = get_resp.json().get("sha")
+    for attempt in range(max_retries):
+        # Step 1: Check if file already exists to get its SHA
+        get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
+        sha = get_resp.json().get("sha") if get_resp.status_code == 200 else None
 
-    # Step 2: Prepare upload payload
-    upload_payload = {
-        "message": f"Upload {filename}",
-        "content": content,
-        "branch": branch
-    }
-    if sha:
-        upload_payload["sha"] = sha  # Needed for overwrite
+        # Step 2: Prepare upload payload
+        upload_payload = {
+            "message": f"Upload {filename}",
+            "content": content,
+            "branch": branch
+        }
+        if sha:
+            upload_payload["sha"] = sha  # Needed for overwrite
 
-    # Step 3: Upload (PUT) to GitHub
-    upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
-    if upload_resp.status_code not in [200, 201]:
+        # Step 3: Upload (PUT) to GitHub
+        upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
+        if upload_resp.status_code in [200, 201]:
+            # Step 4: Add raw_url manually
+            response_json = upload_resp.json()
+            raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
+            response_json['content']['raw_url'] = raw_url
+            return response_json
+
+        if upload_resp.status_code == 409 and attempt < max_retries - 1:
+            # Branch moved; retry after fetching the latest SHA
+            continue
+
         raise Exception(f"❌ GitHub upload failed: {upload_resp.status_code} - {upload_resp.text}")
-
-    # Step 4: Add raw_url manually
-    response_json = upload_resp.json()
-    raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
-    response_json['content']['raw_url'] = raw_url
-    return response_json
 
 def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     airtable_headers = {

--- a/code/intraday/data_upload_utils.py
+++ b/code/intraday/data_upload_utils.py
@@ -6,7 +6,9 @@ import requests
 # previous hard-coded value. Defaults to the common "Attachments" field.
 ATTACHMENT_FIELD = os.getenv("AIRTABLE_ATTACHMENT_FIELD", "Attachments")
 
-def upload_to_github(filename, repo_name, branch, upload_path, token):
+def upload_to_github(filename, repo_name, branch, upload_path, token, max_retries=3):
+    """Upload a file to GitHub, retrying on 409 conflicts."""
+
     with open(filename, "rb") as f:
         content = base64.b64encode(f.read()).decode()
 
@@ -16,31 +18,34 @@ def upload_to_github(filename, repo_name, branch, upload_path, token):
         "Accept": "application/vnd.github+json"
     }
 
-    # Step 1: Check if file already exists to get its SHA
-    get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
-    sha = None
-    if get_resp.status_code == 200:
-        sha = get_resp.json().get("sha")
+    for attempt in range(max_retries):
+        # Step 1: Check if file already exists to get its SHA
+        get_resp = requests.get(f"{upload_url}?ref={branch}", headers=headers)
+        sha = get_resp.json().get("sha") if get_resp.status_code == 200 else None
 
-    # Step 2: Prepare upload payload
-    upload_payload = {
-        "message": f"Upload {filename}",
-        "content": content,
-        "branch": branch
-    }
-    if sha:
-        upload_payload["sha"] = sha  # Needed for overwrite
+        # Step 2: Prepare upload payload
+        upload_payload = {
+            "message": f"Upload {filename}",
+            "content": content,
+            "branch": branch
+        }
+        if sha:
+            upload_payload["sha"] = sha  # Needed for overwrite
 
-    # Step 3: Upload (PUT) to GitHub
-    upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
-    if upload_resp.status_code not in [200, 201]:
+        # Step 3: Upload (PUT) to GitHub
+        upload_resp = requests.put(upload_url, headers=headers, json=upload_payload)
+        if upload_resp.status_code in [200, 201]:
+            # Step 4: Add raw_url manually
+            response_json = upload_resp.json()
+            raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
+            response_json['content']['raw_url'] = raw_url
+            return response_json
+
+        if upload_resp.status_code == 409 and attempt < max_retries - 1:
+            # Branch moved; retry after fetching the latest SHA
+            continue
+
         raise Exception(f"❌ GitHub upload failed: {upload_resp.status_code} - {upload_resp.text}")
-
-    # Step 4: Add raw_url manually
-    response_json = upload_resp.json()
-    raw_url = f"https://raw.githubusercontent.com/{repo_name}/{branch}/{upload_path}/{filename}"
-    response_json['content']['raw_url'] = raw_url
-    return response_json
 
 def update_airtable(record_id, raw_url, filename, airtable_url, airtable_token):
     airtable_headers = {


### PR DESCRIPTION
## Summary
- add retry logic to `upload_to_github` so uploads retry on 409 conflicts

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`