### PR TITLE
Add CoinGecko crypto scripts

### DIFF
--- a/code/daily/coingecko_altcoin_price_top100.py
+++ b/code/daily/coingecko_altcoin_price_top100.py
@@ -1,0 +1,63 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Initialize CoinGecko with API key ===
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+# === Fetch top 100 coins by market cap ===
+markets = cg.get_coins_markets(vs_currency="usd", order="market_cap_desc", per_page=100, page=1)
+records = [{
+    "Symbol": entry["symbol"].upper(),
+    "Name": entry["name"],
+    "Price (USD)": entry["current_price"]
+} for entry in markets]
+
+df = pd.DataFrame(records)
+filename = "coingecko_top100_altcoin_prices.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists in Airtable ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko Top100 Altcoin Prices"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko Top100 Altcoin Prices", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko top 100 altcoin prices uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/coingecko_btc_daily_returns.py
+++ b/code/daily/coingecko_btc_daily_returns.py
@@ -1,0 +1,64 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Initialize CoinGecko with API key ===
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+# === Fetch BTC price history and compute daily returns ===
+market_data = cg.get_coin_market_chart_by_id(id="bitcoin", vs_currency="usd", days=365)
+prices = market_data["prices"]
+
+price_df = pd.DataFrame(prices, columns=["timestamp", "price"])
+price_df["Date"] = pd.to_datetime(price_df["timestamp"], unit="ms").dt.strftime("%Y-%m-%d")
+price_df["Return"] = price_df["price"].pct_change() * 100
+price_df = price_df.dropna()[["Date", "Return"]]
+
+filename = "bitcoin_daily_returns.xlsx"
+price_df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists in Airtable ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko BTC Daily Returns"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko BTC Daily Returns", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko BTC daily returns uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/coingecko_btc_daily_volume.py
+++ b/code/daily/coingecko_btc_daily_volume.py
@@ -1,0 +1,58 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+market_data = cg.get_coin_market_chart_by_id(id="bitcoin", vs_currency="usd", days=365)
+volume_data = market_data["total_volumes"]
+
+records = [{
+    "Date": datetime.utcfromtimestamp(ts/1000).strftime("%Y-%m-%d"),
+    "BTC Volume (USD)": vol
+} for ts, vol in volume_data]
+
+df = pd.DataFrame(records)
+filename = "bitcoin_daily_volume.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko BTC Daily Volume"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko BTC Daily Volume", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko BTC daily volume uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/coingecko_crypto_price_daily.py
+++ b/code/daily/coingecko_crypto_price_daily.py
@@ -1,0 +1,69 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Initialize CoinGecko with API key ===
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+# === Fetch 365 days of daily prices for BTC and ETH ===
+coins = {"BTC": "bitcoin", "ETH": "ethereum"}
+records = []
+for symbol, coin_id in coins.items():
+    market_data = cg.get_coin_market_chart_by_id(id=coin_id, vs_currency="usd", days=365)
+    for ts, price in market_data["prices"]:
+        records.append({
+            "Date": datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d"),
+            "Symbol": symbol,
+            "Close Price (USD)": price
+        })
+
+# === Save to Excel ===
+df = pd.DataFrame(records)
+filename = "coingecko_prices_daily.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists in Airtable ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko BTC & ETH Price Daily"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko BTC & ETH Price Daily", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko BTC & ETH daily prices uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/coingecko_eth_daily_volume.py
+++ b/code/daily/coingecko_eth_daily_volume.py
@@ -1,0 +1,58 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+market_data = cg.get_coin_market_chart_by_id(id="ethereum", vs_currency="usd", days=365)
+volume_data = market_data["total_volumes"]
+
+records = [{
+    "Date": datetime.utcfromtimestamp(ts/1000).strftime("%Y-%m-%d"),
+    "ETH Volume (USD)": vol
+} for ts, vol in volume_data]
+
+df = pd.DataFrame(records)
+filename = "ethereum_daily_volume.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko ETH Daily Volume"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko ETH Daily Volume", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko ETH daily volume uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/coingecko_stablecoin_peg_deviation.py
+++ b/code/daily/coingecko_stablecoin_peg_deviation.py
@@ -1,0 +1,68 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+stablecoins = {
+    "USDT": "tether",
+    "USDC": "usd-coin",
+    "DAI": "dai",
+    "TUSD": "true-usd"
+}
+
+records = []
+for symbol, coin_id in stablecoins.items():
+    data = cg.get_coin_market_chart_by_id(id=coin_id, vs_currency="usd", days=365)
+    for ts, price in data["prices"]:
+        deviation = price - 1
+        records.append({
+            "Date": datetime.utcfromtimestamp(ts/1000).strftime("%Y-%m-%d"),
+            "Symbol": symbol,
+            "Peg Deviation": deviation
+        })
+
+df = pd.DataFrame(records)
+filename = "stablecoin_peg_deviation.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko Stablecoin Peg Deviation"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko Stablecoin Peg Deviation", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko stablecoin peg deviation uploaded to Airtable and GitHub cleaned up.")

--- a/code/intraday/coingecko_crypto_price_1m.py
+++ b/code/intraday/coingecko_crypto_price_1m.py
@@ -1,0 +1,69 @@
+from pycoingecko import CoinGeckoAPI
+import pandas as pd
+from datetime import datetime
+import os
+import requests
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Initialize CoinGecko with API key ===
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY", "CG-eFCtjc4Mocq5xr7kno7b8qUm")
+cg = CoinGeckoAPI(api_key=COINGECKO_API_KEY)
+
+# === Fetch 1 minute prices for BTC and ETH over the last day ===
+coins = {"BTC": "bitcoin", "ETH": "ethereum"}
+records = []
+for symbol, coin_id in coins.items():
+    market_data = cg.get_coin_market_chart_by_id(id=coin_id, vs_currency="usd", days=1, interval="minutely")
+    for ts, price in market_data["prices"]:
+        records.append({
+            "DateTime": datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d %H:%M"),
+            "Symbol": symbol,
+            "Price (USD)": price
+        })
+
+# === Save to Excel ===
+df = pd.DataFrame(records)
+filename = "coingecko_prices_1m.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "intraday"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists in Airtable ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+
+existing_records = [
+    rec for rec in records_airtable
+    if rec['fields'].get('Name') == "CoinGecko BTC & ETH Price 1m"
+]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record("CoinGecko BTC & ETH Price 1m", raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinGecko BTC & ETH Price 1m uploaded to Airtable and GitHub cleaned up.")


### PR DESCRIPTION
## Summary
- add intraday script for BTC and ETH 1m prices via CoinGecko
- add daily scripts for BTC/ETH price, volume, BTC returns
- add top 100 altcoin price grabber
- add stablecoin peg deviation script

## Testing
- `pytest -q`
