### PR TITLE
Add individual crypto indicators

### DIFF
--- a/code/daily/AlphaVantage DXY.py
+++ b/code/daily/AlphaVantage DXY.py
@@ -1,0 +1,63 @@
+import os
+import requests
+import pandas as pd
+from datetime import datetime
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+API_KEY = os.getenv("ALPHAVANTAGE_API_KEY", "BDLHVHE5630WUQQC")
+url = f"https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=DXY&apikey={API_KEY}&outputsize=full"
+response = requests.get(url)
+response.raise_for_status()
+data = response.json().get("Time Series (Daily)", {})
+
+records = []
+for date_str, values in data.items():
+    records.append({
+        "Date": date_str,
+        "DXY Close Price (USD)": float(values["4. close"])
+    })
+records.sort(key=lambda x: x["Date"])
+
+# === Save to Excel ===
+df = pd.DataFrame(records)
+filename = "alphavantage_dxy_daily.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "AlphaVantage DXY Daily Close"
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json"
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ AlphaVantage DXY data uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/Alternative.me Fear and Greed Index.py
+++ b/code/daily/Alternative.me Fear and Greed Index.py
@@ -1,0 +1,63 @@
+import os
+import requests
+import pandas as pd
+from datetime import datetime
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Fetch Fear & Greed Index ===
+response = requests.get("https://api.alternative.me/fng/?format=json&limit=730")
+response.raise_for_status()
+entries = response.json().get("data", [])
+
+records = []
+for entry in entries:
+    date = datetime.utcfromtimestamp(int(entry["timestamp"])).strftime("%Y-%m-%d")
+    records.append({
+        "Date": date,
+        "Fear & Greed Index": int(entry["value"]),
+        "Classification": entry["value_classification"],
+    })
+
+# === Save to Excel ===
+df = pd.DataFrame(records)
+filename = "fear_greed_index.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Fear & Greed Index"
+
+# === Upload to GitHub ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+# === Check if record exists in Airtable ===
+airtable_headers = {
+    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+    "Content-Type": "application/json",
+}
+response = requests.get(airtable_url, headers=airtable_headers)
+response.raise_for_status()
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+# === Update or create record ===
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Fear & Greed Index uploaded to Airtable and GitHub cleaned up.")

--- a/code/daily/Binance Funding Rate.py
+++ b/code/daily/Binance Funding Rate.py
@@ -1,0 +1,64 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+)
+
+symbols = ["BTCUSDT", "ETHUSDT"]
+records = []
+for symbol in symbols:
+    resp = requests.get(
+        f"https://fapi.binance.com/fapi/v1/fundingRate?symbol={symbol}&limit=1"
+    )
+    resp.raise_for_status()
+    item = resp.json()[0]
+    records.append(
+        {
+            "Symbol": symbol,
+            "Funding Rate": item.get("fundingRate"),
+            "Funding Time": item.get("fundingTime"),
+        }
+    )
+
+# === Save to Excel ===
+df = pd.DataFrame(records)
+filename = "binance_funding_rate.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Binance Funding Rate"
+
+# === Upload ===
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response["content"]["raw_url"]
+file_sha = github_response["content"]["sha"]
+
+# === Airtable ===
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Binance funding rate uploaded.")

--- a/code/daily/Binance Liquidations.py
+++ b/code/daily/Binance Liquidations.py
@@ -1,0 +1,46 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+symbols = ["BTCUSDT", "ETHUSDT"]
+records = []
+for symbol in symbols:
+    resp = requests.get(f"https://fapi.binance.com/futures/data/orderLiquidation?symbol={symbol}&limit=1")
+    resp.raise_for_status()
+    item = resp.json()[0]
+    records.append({"Symbol": symbol, "Price": item.get("price"), "Side": item.get("side"), "Time": item.get("time")})
+
+df = pd.DataFrame(records)
+filename = "binance_liquidations.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Binance Liquidations"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Binance liquidations uploaded.")

--- a/code/daily/Binance Open Interest.py
+++ b/code/daily/Binance Open Interest.py
@@ -1,0 +1,58 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+)
+
+symbols = ["BTCUSDT", "ETHUSDT"]
+records = []
+for symbol in symbols:
+    resp = requests.get(
+        f"https://fapi.binance.com/futures/data/openInterestHist?symbol={symbol}&period=5m&limit=1"
+    )
+    resp.raise_for_status()
+    item = resp.json()[0]
+    records.append({"Symbol": symbol, "Open Interest": item.get("sumOpenInterestValue"), "Timestamp": item.get("timestamp")})
+
+# === Save ===
+df = pd.DataFrame(records)
+filename = "binance_open_interest.xlsx"
+df.to_excel(filename, index=False)
+
+# === Config ===
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Binance Open Interest"
+
+# === Upload ===
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+# === Airtable ===
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+# === Cleanup ===
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Binance open interest uploaded.")

--- a/code/daily/Binance Order Book.py
+++ b/code/daily/Binance Order Book.py
@@ -1,0 +1,53 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+symbols = ["BTCUSDT", "ETHUSDT"]
+records = []
+for symbol in symbols:
+    # Spot order book
+    spot = requests.get(f"https://api.binance.com/api/v3/depth?symbol={symbol}&limit=5").json()
+    # Futures order book
+    fut = requests.get(f"https://fapi.binance.com/fapi/v1/depth?symbol={symbol}&limit=5").json()
+    records.append({
+        "Symbol": symbol,
+        "Spot Bid 1": spot.get("bids", [[None]])[0][0],
+        "Spot Ask 1": spot.get("asks", [[None]])[0][0],
+        "Futures Bid 1": fut.get("bids", [[None]])[0][0],
+        "Futures Ask 1": fut.get("asks", [[None]])[0][0],
+    })
+
+df = pd.DataFrame(records)
+filename = "binance_order_book.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Binance Order Book"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Binance order book uploaded.")

--- a/code/daily/Blockchair Stats.py
+++ b/code/daily/Blockchair Stats.py
@@ -1,0 +1,46 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+CHAIN = os.getenv("BLOCKCHAIR_CHAIN", "bitcoin")
+url = f"https://api.blockchair.com/{CHAIN}/stats"
+response = requests.get(url)
+response.raise_for_status()
+stats = response.json().get("data", {}).get(CHAIN, {})
+
+records = [{"Metric": k, "Value": v} for k, v in stats.items() if isinstance(v, (int, float, str))]
+
+df = pd.DataFrame(records)
+filename = "blockchair_stats.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = f"Blockchair {CHAIN} Stats"
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Blockchair stats uploaded.")

--- a/code/daily/DefiLlama DEX Volume.py
+++ b/code/daily/DefiLlama DEX Volume.py
@@ -1,0 +1,46 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+resp = requests.get("https://api.llama.fi/overview/dexs")
+resp.raise_for_status()
+data = resp.json()
+records = [
+    {"Metric": "DEX Volume 24h", "Value": data.get("totalVolume24h")},
+    {"Metric": "DEX TVL", "Value": data.get("totalLiquidityUSD")},
+]
+
+df = pd.DataFrame(records)
+filename = "defillama_dex_volume.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "DefiLlama DEX Volume"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ DefiLlama DEX volume uploaded.")

--- a/code/daily/DefiLlama TVL.py
+++ b/code/daily/DefiLlama TVL.py
@@ -1,0 +1,44 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+# === Fetch global DeFi TVL ===
+resp = requests.get("https://api.llama.fi/tvl")
+resp.raise_for_status()
+value = resp.json().get("tvl")
+records = [{"Metric": "Total DeFi TVL", "Value": value}]
+
+df = pd.DataFrame(records)
+filename = "defillama_tvl.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "DefiLlama TVL"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ DefiLlama TVL uploaded.")

--- a/code/daily/Etherscan Gas Prices.py
+++ b/code/daily/Etherscan Gas Prices.py
@@ -1,0 +1,49 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+API_KEY = os.getenv("ETHERSCAN_API_KEY", "R1C32K1CWPMNJFWWNFIA51QGPSNRAAEBRJ")
+resp = requests.get(f"https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey={API_KEY}")
+resp.raise_for_status()
+oracle = resp.json().get("result", {})
+
+records = [
+    {"Metric": "Gas Price Safe (Gwei)", "Value": oracle.get("SafeGasPrice")},
+    {"Metric": "Gas Price Propose (Gwei)", "Value": oracle.get("ProposeGasPrice")},
+    {"Metric": "Gas Price Fast (Gwei)", "Value": oracle.get("FastGasPrice")},
+]
+
+df = pd.DataFrame(records)
+filename = "etherscan_gas_prices.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Etherscan Gas Prices"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Etherscan gas prices uploaded.")

--- a/code/daily/Etherscan Token Events.py
+++ b/code/daily/Etherscan Token Events.py
@@ -1,0 +1,54 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+API_KEY = os.getenv("ETHERSCAN_API_KEY", "R1C32K1CWPMNJFWWNFIA51QGPSNRAAEBRJ")
+ADDRESS = os.getenv("ETHERSCAN_ADDRESS", "0xdAC17F958D2ee523a2206206994597C13D831ec7")
+resp = requests.get(f"https://api.etherscan.io/api?module=account&action=tokentx&address={ADDRESS}&page=1&offset=10&sort=desc&apikey={API_KEY}")
+resp.raise_for_status()
+items = resp.json().get("result", [])
+
+records = []
+for item in items:
+    records.append({
+        "TxHash": item.get("hash"),
+        "Value": item.get("value"),
+        "Token": item.get("tokenSymbol"),
+        "TimeStamp": item.get("timeStamp"),
+    })
+
+
+df = pd.DataFrame(records)
+filename = "etherscan_token_events.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Etherscan Token Events"
+
+res = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = res["content"]["raw_url"]
+file_sha = res["content"]["sha"]
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get("records", [])
+existing_records = [rec for rec in records_airtable if rec["fields"].get("Name") == INDICATOR_NAME]
+record_id = existing_records[0]["id"] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Etherscan token events uploaded.")

--- a/code/daily/Mempool Stats.py
+++ b/code/daily/Mempool Stats.py
@@ -1,0 +1,48 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+base_url = "https://mempool.space/api/v1"
+fees = requests.get(f"{base_url}/fees/recommended").json()
+summary = requests.get(f"{base_url}/mempool").json()
+
+records = [
+    {"Metric": "fastFee", "Value": fees.get("fastestFee")},
+    {"Metric": "mempoolSize", "Value": summary.get("count")},
+    {"Metric": "mempoolVsize", "Value": summary.get("vsize")}
+]
+
+df = pd.DataFrame(records)
+filename = "mempool_stats.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "Mempool Stats"
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ Mempool stats uploaded.")

--- a/code/daily/OpenSea NFT Stats.py
+++ b/code/daily/OpenSea NFT Stats.py
@@ -1,0 +1,49 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+OPENSEA_API_KEY = os.getenv("OPENSEA_API_KEY")
+COLLECTION_SLUG = os.getenv("OPENSEA_COLLECTION", "cryptopunks")
+url = f"https://api.opensea.io/api/v1/collection/{COLLECTION_SLUG}/stats"
+headers = {"X-API-KEY": OPENSEA_API_KEY} if OPENSEA_API_KEY else {}
+response = requests.get(url, headers=headers)
+response.raise_for_status()
+stats = response.json().get("stats", {})
+
+records = [{"Metric": "Floor Price", "Value": stats.get("floor_price")},
+           {"Metric": "Total Volume", "Value": stats.get("total_volume")}]
+
+df = pd.DataFrame(records)
+filename = "opensea_nft_stats.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = f"OpenSea {COLLECTION_SLUG} Stats"
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ OpenSea stats uploaded.")

--- a/code/daily/OpenSea NFT Transfers.py
+++ b/code/daily/OpenSea NFT Transfers.py
@@ -1,0 +1,55 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github
+
+OPENSEA_API_KEY = os.getenv("OPENSEA_API_KEY")
+COLLECTION_SLUG = os.getenv("OPENSEA_COLLECTION", "cryptopunks")
+url = f"https://api.opensea.io/api/v2/events?collection_slug={COLLECTION_SLUG}&event_type=transfer&limit=50"
+headers = {"X-API-KEY": OPENSEA_API_KEY} if OPENSEA_API_KEY else {}
+resp = requests.get(url, headers=headers)
+resp.raise_for_status()
+items = resp.json().get("asset_events", [])
+
+records = []
+for ev in items:
+    records.append({
+        "Token": ev.get("asset", {}).get("token_id"),
+        "From": ev.get("from_account", {}).get("address"),
+        "To": ev.get("to_account", {}).get("address"),
+        "Date": ev.get("created_date")
+    })
+
+df = pd.DataFrame(records)
+filename = "opensea_transfers.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = f"OpenSea {COLLECTION_SLUG} Transfers"
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ OpenSea transfers uploaded.")


### PR DESCRIPTION
## Summary
- split Binance data into separate funding rate, open interest, order book and liquidations scripts
- separate DefiLlama metrics into TVL and DEX volume scripts
- divide Etherscan metrics into gas prices and token events
- default ETHERSCAN_API_KEY to the provided key

## Testing
- `pytest -q`
