### PR TITLE
Remove timezone info on Excel export

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ workflows:
 All scripts should ensure date columns are stored using `datetime64[ns, UTC]`
 dtype. Each `data_upload_utils.py` module defines an `ensure_utc` helper and
 monkey-patches `pandas.DataFrame.to_excel` so DataFrames are automatically
-converted to UTC before being written. Simply import one of these utilities and
-call `df.to_excel(...)` as usual.
+converted to UTC and then stripped of timezone information before being written
+to Excel. If a column originally used a timezone other than UTC, the timezone
+name is placed in a new column named `<column>_timezone`. Simply import one of
+these utilities and call `df.to_excel(...)` as usual.

--- a/code/daily/data_upload_utils.py
+++ b/code/daily/data_upload_utils.py
@@ -24,8 +24,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/event_driven/data_upload_utils.py
+++ b/code/event_driven/data_upload_utils.py
@@ -24,8 +24,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/intraday/data_upload_utils.py
+++ b/code/intraday/data_upload_utils.py
@@ -24,8 +24,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/monthly/data_upload_utils.py
+++ b/code/monthly/data_upload_utils.py
@@ -23,8 +23,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/quarterly/data_upload_utils.py
+++ b/code/quarterly/data_upload_utils.py
@@ -23,8 +23,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/weekly/data_upload_utils.py
+++ b/code/weekly/data_upload_utils.py
@@ -24,8 +24,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):

--- a/code/yearly/data_upload_utils.py
+++ b/code/yearly/data_upload_utils.py
@@ -24,8 +24,20 @@ def ensure_utc(df):
 
 _ORIG_TO_EXCEL = pd.DataFrame.to_excel
 
+def _drop_timezone(df):
+    """Remove timezone from datetime columns and store non-UTC tz in new columns."""
+    for col in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            tz = df[col].dt.tz
+            if tz is not None:
+                if str(tz) != "UTC":
+                    df[f"{col}_timezone"] = str(tz)
+                df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    return df
+
 def _to_excel_utc(self, *args, **kwargs):
     self = ensure_utc(self)
+    self = _drop_timezone(self)
     return _ORIG_TO_EXCEL(self, *args, **kwargs)
 
 if not getattr(pd.DataFrame.to_excel, "_utc_patched", False):


### PR DESCRIPTION
## Summary
- strip timezone info before exporting DataFrames to Excel
- document new timezone-handling behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
