### PR TITLE
Fix integer columns unintentionally parsed as datetime

### DIFF
--- a/code/daily/data_upload_utils.py
+++ b/code/daily/data_upload_utils.py
@@ -16,7 +16,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/data_upload_utils.py
+++ b/code/data_upload_utils.py
@@ -17,7 +17,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/event_driven/data_upload_utils.py
+++ b/code/event_driven/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/intraday/data_upload_utils.py
+++ b/code/intraday/data_upload_utils.py
@@ -16,7 +16,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/monthly/data_upload_utils.py
+++ b/code/monthly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/quarterly/data_upload_utils.py
+++ b/code/quarterly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/weekly/data_upload_utils.py
+++ b/code/weekly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/yearly/data_upload_utils.py
+++ b/code/yearly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted


### PR DESCRIPTION
## Summary
- avoid coercing numeric columns to datetime in `ensure_utc`

## Testing
- `pytest -q`
