### PR TITLE
Fix integer columns unintentionally parsed as datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ All scripts should ensure date columns are stored using `datetime64[ns, UTC]`
 dtype. Each `data_upload_utils.py` module defines an `ensure_utc` helper and
 monkey-patches `pandas.DataFrame.to_excel` so DataFrames are automatically
 converted to UTC and then stripped of timezone information before being written
-to Excel. If a column originally used a timezone other than UTC, the timezone
-name is placed in a new column named `<column>_timezone`. Simply import one of
-these utilities and call `df.to_excel(...)` as usual.
+to Excel. Numeric columns are left unchanged; `ensure_utc` only attempts to
+parse object or string columns as datetimes. If a column originally used a
+timezone other than UTC, the timezone name is placed in a new column named
+`<column>_timezone`. Simply import one of these utilities and call
+`df.to_excel(...)` as usual.

--- a/code/daily/data_upload_utils.py
+++ b/code/daily/data_upload_utils.py
@@ -16,7 +16,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/data_upload_utils.py
+++ b/code/data_upload_utils.py
@@ -17,7 +17,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/event_driven/data_upload_utils.py
+++ b/code/event_driven/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/intraday/data_upload_utils.py
+++ b/code/intraday/data_upload_utils.py
@@ -16,7 +16,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/monthly/data_upload_utils.py
+++ b/code/monthly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/quarterly/data_upload_utils.py
+++ b/code/quarterly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/weekly/data_upload_utils.py
+++ b/code/weekly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted

--- a/code/yearly/data_upload_utils.py
+++ b/code/yearly/data_upload_utils.py
@@ -15,7 +15,7 @@ def ensure_utc(df):
                 df[col] = df[col].dt.tz_localize("UTC")
             else:
                 df[col] = df[col].dt.tz_convert("UTC")
-        else:
+        elif pd.api.types.is_object_dtype(df[col]) or pd.api.types.is_string_dtype(df[col]):
             converted = pd.to_datetime(df[col], errors="ignore", utc=True)
             if pd.api.types.is_datetime64_any_dtype(converted):
                 df[col] = converted


### PR DESCRIPTION
## Summary
- avoid coercing numeric columns to datetime in `ensure_utc`
- clarify README about unchanged numeric columns

## Testing
- `pytest -q`
