### PR TITLE
Remove Binance Futures and OpenSea scripts

### DIFF
--- a/.github/workflows/crypto_tests.yml
+++ b/.github/workflows/crypto_tests.yml
@@ -5,25 +5,19 @@ on:
     paths:
       - 'code/daily/AlphaVantage DXY.py'
       - 'code/daily/Alternative.me Fear and Greed Index.py'
-      - 'code/daily/Binance Futures Stats.py'
       - 'code/daily/Blockchair Stats.py'
       - 'code/daily/DefiLlama Stats.py'
       - 'code/daily/Etherscan Stats.py'
       - 'code/daily/Mempool Stats.py'
-      - 'code/daily/OpenSea NFT Stats.py'
-      - 'code/daily/OpenSea NFT Transfers.py'
       - 'tests/**'
   pull_request:
     paths:
       - 'code/daily/AlphaVantage DXY.py'
       - 'code/daily/Alternative.me Fear and Greed Index.py'
-      - 'code/daily/Binance Futures Stats.py'
       - 'code/daily/Blockchair Stats.py'
       - 'code/daily/DefiLlama Stats.py'
       - 'code/daily/Etherscan Stats.py'
       - 'code/daily/Mempool Stats.py'
-      - 'code/daily/OpenSea NFT Stats.py'
-      - 'code/daily/OpenSea NFT Transfers.py'
       - 'tests/**'
 
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,6 @@ jobs:
           - "code/daily/24h Volatility & Trading Range.py"
           - "code/daily/BTC ETF Net Flow.py"
           - "code/daily/BTCPriceDaily.py"
-          - "code/daily/CoinDeskSentiment.py"
           - "code/daily/CurrencyExchange.py"
           - "code/daily/Exchange Rates (Investing.com).py"
           - "code/daily/GoldDailyPrice.py"
@@ -65,13 +64,10 @@ jobs:
           - "code/daily/Active Addresses.py"
           - "code/daily/AlphaVantage DXY.py"
           - "code/daily/Alternative.me Fear and Greed Index.py"
-          - "code/daily/Binance Futures Stats.py"
           - "code/daily/Blockchair Stats.py"
           - "code/daily/DefiLlama Stats.py"
           - "code/daily/Etherscan Stats.py"
           - "code/daily/Mempool Stats.py"
-          - "code/daily/OpenSea NFT Stats.py"
-          - "code/daily/OpenSea NFT Transfers.py"
 
     steps:
       - name: Checkout repository

--- a/tests/test_crypto_scripts.py
+++ b/tests/test_crypto_scripts.py
@@ -4,13 +4,10 @@ import pytest
 SCRIPTS = [
     'code/daily/AlphaVantage DXY.py',
     'code/daily/Alternative.me Fear and Greed Index.py',
-    'code/daily/Binance Futures Stats.py',
     'code/daily/Blockchair Stats.py',
     'code/daily/DefiLlama Stats.py',
     'code/daily/Etherscan Stats.py',
     'code/daily/Mempool Stats.py',
-    'code/daily/OpenSea NFT Stats.py',
-    'code/daily/OpenSea NFT Transfers.py',
 ]
 
 @pytest.mark.parametrize('path', SCRIPTS)


### PR DESCRIPTION
## Summary
- drop references to Binance Futures Stats, OpenSea NFT Stats, and OpenSea NFT Transfers
- harden mempool stats script against non-JSON API responses

## Testing
- `pytest -q`