### PR TITLE
Add CoinMetrics indicators and workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,6 +14,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
       COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
+      COINMETRICS_API_KEY: ${{ secrets.COINMETRICS_API_KEY }}
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -68,6 +69,7 @@ jobs:
           - "code/daily/DefiLlama Stats.py"
           - "code/daily/Etherscan Stats.py"
           - "code/daily/Mempool Stats.py"
+          - "code/daily/CoinMetrics Indicators.py"
 
     steps:
       - name: Checkout repository

--- a/code/daily/CoinMetrics Indicators.py
+++ b/code/daily/CoinMetrics Indicators.py
@@ -1,0 +1,89 @@
+import os
+import requests
+import pandas as pd
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+)
+
+# Use env variable if available, otherwise fall back to provided demo key
+API_KEY = os.getenv("COINMETRICS_API_KEY", "BLgxPvn1qdWWzTqh7fx3")
+BASE_URL = "https://api.coinmetrics.io/v4"
+
+headers = {"X-CoinMetrics-Api-Key": API_KEY}
+
+def fetch(endpoint: str, params: dict) -> list:
+    try:
+        resp = requests.get(endpoint, params=params, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+    except (requests.exceptions.RequestException, ValueError):
+        return []
+
+asset_params = {
+    "assets": "btc",
+    "metrics": "AdrActCnt,TxCnt,HashRateMean,SplyCur,CapMVRVCur",
+    "frequency": "1d",
+    "page_size": 1,
+}
+
+market_params = {
+    "markets": "coinbase-btc-usd-spot",
+    "frequency": "1d",
+    "page_size": 1,
+}
+
+asset_data = fetch(f"{BASE_URL}/timeseries/asset-metrics", asset_params)
+market_data = fetch(f"{BASE_URL}/timeseries/market-candles", market_params)
+
+latest_asset = asset_data[-1] if asset_data else {}
+latest_market = market_data[-1] if market_data else {}
+
+records = [
+    {
+        "Date": latest_asset.get("time") or latest_market.get("time"),
+        "Active Addresses": latest_asset.get("AdrActCnt"),
+        "Transaction Count": latest_asset.get("TxCnt"),
+        "Hash Rate": latest_asset.get("HashRateMean"),
+        "Current Supply": latest_asset.get("SplyCur"),
+        "MVRV Current": latest_asset.get("CapMVRVCur"),
+        "Close Price": latest_market.get("close"),
+    }
+]
+
+
+df = pd.DataFrame(records)
+filename = "coinmetrics_indicators.xlsx"
+df.to_excel(filename, index=False)
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = "appnssPRD9yeYJJe5"
+TABLE_NAME = "daily"
+airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
+
+GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"
+BRANCH = "main"
+UPLOAD_PATH = "Uploads"
+GITHUB_TOKEN = os.getenv("GH_TOKEN")
+INDICATOR_NAME = "CoinMetrics Indicators"
+
+github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+raw_url = github_response['content']['raw_url']
+file_sha = github_response['content']['sha']
+
+airtable_headers = {"Authorization": f"Bearer {AIRTABLE_API_KEY}", "Content-Type": "application/json"}
+response = requests.get(airtable_url, headers=airtable_headers)
+records_airtable = response.json().get('records', [])
+existing_records = [rec for rec in records_airtable if rec['fields'].get('Name') == INDICATOR_NAME]
+record_id = existing_records[0]['id'] if existing_records else None
+
+if record_id:
+    update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+else:
+    create_airtable_record(INDICATOR_NAME, raw_url, filename, airtable_url, AIRTABLE_API_KEY)
+
+delete_file_from_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN, file_sha)
+os.remove(filename)
+print("✅ CoinMetrics indicators uploaded.")

--- a/tests/test_crypto_scripts.py
+++ b/tests/test_crypto_scripts.py
@@ -8,6 +8,7 @@ SCRIPTS = [
     'code/daily/DefiLlama Stats.py',
     'code/daily/Etherscan Stats.py',
     'code/daily/Mempool Stats.py',
+    'code/daily/CoinMetrics Indicators.py',
 ]
 
 @pytest.mark.parametrize('path', SCRIPTS)


### PR DESCRIPTION
## Summary
- use env var for CoinMetrics API key and collect more network stats
- include CoinMetrics script in daily workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68373e660ad48323bb0cfc3f09a48a2a