### PR TITLE
Increase parallel jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,6 +9,7 @@ jobs:
   run-daily-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -17,7 +18,7 @@ jobs:
       COINMETRICS_API_KEY: ${{ secrets.COINMETRICS_API_KEY }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/daily/24h Volatility & Trading Range.py"

--- a/.github/workflows/event_driven.yml
+++ b/.github/workflows/event_driven.yml
@@ -7,9 +7,10 @@ jobs:
   run-event-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/event_driven/BitcoinHalving.py"

--- a/.github/workflows/intraday.yml
+++ b/.github/workflows/intraday.yml
@@ -9,6 +9,7 @@ jobs:
   run-intraday-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -16,7 +17,7 @@ jobs:
       COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/intraday/bitcoin_close_15min.py"

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -9,9 +9,10 @@ jobs:
   run-monthly-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/monthly/Building Permits.py"

--- a/.github/workflows/quarterly.yml
+++ b/.github/workflows/quarterly.yml
@@ -9,9 +9,10 @@ jobs:
   run-quarterly-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/quarterly/Current Account Balance (OECD).py"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,9 +9,10 @@ jobs:
   run-weekly-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 10
       matrix:
         script:
           - "code/weekly/bitcoin_close_1wk.py"

--- a/.github/workflows/yearly.yml
+++ b/.github/workflows/yearly.yml
@@ -9,9 +9,10 @@ jobs:
   run-yearly-scripts:
     name: ${{ matrix.script }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         script:
           - "code/yearly/GlobalGDP.py"


### PR DESCRIPTION
## Summary
- bump `max-parallel` from 5 to 10 in all workflow matrices
- add `timeout-minutes: 60` for each workflow job

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a15cfe9f88323b9e98dc25d84d8c2