### PR TITLE
Add detailed duplicate API report generator

### DIFF
--- a/code/api_duplicates_detail.py
+++ b/code/api_duplicates_detail.py
@@ -1,0 +1,37 @@
+import os
+import csv
+from urllib.parse import urlparse
+
+CSV_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'api_summary.csv')
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'uploads')
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, 'api_duplicates_detail.csv')
+
+# Read api_summary.csv
+with open(CSV_PATH, newline='') as f:
+    reader = csv.DictReader(f)
+    rows = list(reader)
+
+# Build mapping of endpoint -> list of (script, api)
+endpoint_map = {}
+for row in rows:
+    if row.get('Overlap', '').lower() != 'yes':
+        continue
+    endpoints = [e.strip() for e in row.get('Endpoints', '').split(';') if e.strip()]
+    for ep in endpoints:
+        domain = urlparse(ep).netloc or 'Unknown'
+        endpoint_map.setdefault(ep, []).append((row['Script'], domain))
+
+# Filter to only endpoints that appear in more than one script
+endpoint_map = {ep: infos for ep, infos in endpoint_map.items() if len(infos) > 1}
+
+# Ensure uploads dir exists
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+with open(OUTPUT_FILE, 'w', newline='') as f:
+    writer = csv.writer(f)
+    writer.writerow(['Endpoint', 'Script', 'API'])
+    for endpoint in sorted(endpoint_map):
+        for script, api in sorted(endpoint_map[endpoint]):
+            writer.writerow([endpoint, script, api])
+
+print(f"✅ Detailed duplicate API list written to {OUTPUT_FILE}")

--- a/uploads/api_duplicates_detail.csv
+++ b/uploads/api_duplicates_detail.csv
@@ -1,0 +1,21 @@
+Endpoint,Script,API
+https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey={API_KEY},code/daily/Etherscan Gas Prices.py,api.etherscan.io
+https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey={API_KEY},code/daily/Etherscan Stats.py,api.etherscan.io
+https://api.llama.fi/overview/dexs,code/daily/DefiLlama DEX Volume.py,api.llama.fi
+https://api.llama.fi/overview/dexs,code/daily/DefiLlama Stats.py,api.llama.fi
+https://api.llama.fi/tvl,code/daily/DefiLlama Stats.py,api.llama.fi
+https://api.llama.fi/tvl,code/daily/DefiLlama TVL.py,api.llama.fi
+https://api.stlouisfed.org/fred/series/observations,code/daily/Exchange Rates (Investing.com).py,api.stlouisfed.org
+https://api.stlouisfed.org/fred/series/observations,code/quarterly/Government Budget Balance (OECD).py,api.stlouisfed.org
+https://fapi.binance.com/fapi/v1/depth?symbol={symbol}&limit=5,code/daily/Binance Futures Stats.py,fapi.binance.com
+https://fapi.binance.com/fapi/v1/depth?symbol={symbol}&limit=5,code/daily/Binance Order Book.py,fapi.binance.com
+https://fapi.binance.com/fapi/v1/fundingRate?symbol={symbol}&limit=1,code/daily/Binance Funding Rate.py,fapi.binance.com
+https://fapi.binance.com/fapi/v1/fundingRate?symbol={symbol}&limit=1,code/daily/Binance Futures Stats.py,fapi.binance.com
+https://fapi.binance.com/futures/data/openInterestHist?symbol={symbol}&period=5m&limit=1,code/daily/Binance Futures Stats.py,fapi.binance.com
+https://fapi.binance.com/futures/data/openInterestHist?symbol={symbol}&period=5m&limit=1,code/daily/Binance Open Interest.py,fapi.binance.com
+https://fapi.binance.com/futures/data/orderLiquidation?symbol={symbol}&limit=1,code/daily/Binance Futures Stats.py,fapi.binance.com
+https://fapi.binance.com/futures/data/orderLiquidation?symbol={symbol}&limit=1,code/daily/Binance Liquidations.py,fapi.binance.com
+https://www.imf.org/en/Publications/FM,code/event_driven/fetch_fiscal_stimulus_measures.py,www.imf.org
+https://www.imf.org/en/Publications/FM,code/event_driven/fetch_infrastructure_spending.py,www.imf.org
+https://www.sanctionsmap.eu/,code/event_driven/fetch_international_sanctions.py,www.sanctionsmap.eu
+https://www.sanctionsmap.eu/,code/event_driven/fetch_trade_sanctions.py,www.sanctionsmap.eu


### PR DESCRIPTION
## Summary
- create `api_duplicates_detail.py` to output per-file API duplicates
- generate initial `uploads/api_duplicates_detail.csv`

## Testing
- `pytest -q`
- `python3 code/api_duplicates_detail.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a958b7e88323b1320fcbebb5c62f