### PR TITLE
Ensure TIPS scripts overwrite Airtable records

### DIFF
--- a/code/monthly/20-Year TIPS Yield.py
+++ b/code/monthly/20-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "20-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "20-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/monthly/30-Year TIPS Yield.py
+++ b/code/monthly/30-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "30-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "30-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/monthly/5-Year TIPS Yield.py
+++ b/code/monthly/5-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "5-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "5-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/monthly/data_upload_utils.py
+++ b/code/monthly/data_upload_utils.py
@@ -59,6 +59,7 @@ __all__ = [
     "create_airtable_record",
     "update_airtable",
     "delete_file_from_github",
+    "find_record_id_by_name",
 ]
 
 def upload_to_github(filename, repo_name, branch, upload_path, token, max_retries=3):
@@ -190,3 +191,16 @@ def delete_file_from_github(filename, repo_name, branch, upload_path, token, sha
             return
 
         raise Exception(f"❌ GitHub file deletion failed: {delete_resp.status_code} - {delete_resp.text}")
+
+
+def find_record_id_by_name(name, airtable_url, airtable_token):
+    """Return the Airtable record ID with the given Name."""
+    headers = {
+        "Authorization": f"Bearer {airtable_token}",
+        "Content-Type": "application/json",
+    }
+    params = {"filterByFormula": f"{{Name}}='{name}'", "maxRecords": 1}
+    resp = requests.get(airtable_url, headers=headers, params=params)
+    resp.raise_for_status()
+    records = resp.json().get("records", [])
+    return records[0]["id"] if records else None

--- a/code/weekly/20-Year TIPS Yield.py
+++ b/code/weekly/20-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "20-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "20-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/weekly/30-Year TIPS Yield.py
+++ b/code/weekly/30-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "30-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "30-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/weekly/5-Year TIPS Yield.py
+++ b/code/weekly/5-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "5-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "5-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/weekly/data_upload_utils.py
+++ b/code/weekly/data_upload_utils.py
@@ -60,6 +60,7 @@ __all__ = [
     "create_airtable_record",
     "update_airtable",
     "delete_file_from_github",
+    "find_record_id_by_name",
 ]
 
 
@@ -190,3 +191,16 @@ def delete_file_from_github(filename, repo_name, branch, upload_path, token, sha
             return
 
         raise Exception(f"❌ GitHub file deletion failed: {delete_resp.status_code} - {delete_resp.text}")
+
+
+def find_record_id_by_name(name, airtable_url, airtable_token):
+    """Return the Airtable record ID with the given Name."""
+    headers = {
+        "Authorization": f"Bearer {airtable_token}",
+        "Content-Type": "application/json",
+    }
+    params = {"filterByFormula": f"{{Name}}='{name}'", "maxRecords": 1}
+    resp = requests.get(airtable_url, headers=headers, params=params)
+    resp.raise_for_status()
+    records = resp.json().get("records", [])
+    return records[0]["id"] if records else None

--- a/code/yearly/20-Year TIPS Yield.py
+++ b/code/yearly/20-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "20-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "20-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/yearly/30-Year TIPS Yield.py
+++ b/code/yearly/30-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "30-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "30-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/yearly/5-Year TIPS Yield.py
+++ b/code/yearly/5-Year TIPS Yield.py
@@ -4,7 +4,14 @@ import os
 import requests
 import time
 from fredapi import Fred
-from data_upload_utils import upload_to_github, create_airtable_record, update_airtable, delete_file_from_github, ensure_utc
+from data_upload_utils import (
+    upload_to_github,
+    create_airtable_record,
+    update_airtable,
+    delete_file_from_github,
+    ensure_utc,
+    find_record_id_by_name,
+)
 
 # === Secrets & Config ===
 FRED_API_KEY = os.getenv("FRED_API_KEY")
@@ -56,19 +63,9 @@ github_response = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, G
 raw_url = github_response['content']['raw_url']
 file_sha = github_response['content']['sha']
 
-airtable_headers = {
-    "Authorization": f"Bearer {AIRTABLE_API_KEY}",
-    "Content-Type": "application/json"
-}
-response = requests.get(airtable_url, headers=airtable_headers)
-response.raise_for_status()
-data_airtable = response.json()
-
-existing_records = [
-    rec for rec in data_airtable['records']
-    if rec['fields'].get('Name') == "5-Year TIPS Yield (%)"
-]
-record_id = existing_records[0]['id'] if existing_records else None
+record_id = find_record_id_by_name(
+    "5-Year TIPS Yield (%)", airtable_url, AIRTABLE_API_KEY
+)
 
 if record_id:
     update_airtable(record_id, raw_url, filename, airtable_url, AIRTABLE_API_KEY)

--- a/code/yearly/data_upload_utils.py
+++ b/code/yearly/data_upload_utils.py
@@ -60,6 +60,7 @@ __all__ = [
     "create_airtable_record",
     "update_airtable",
     "delete_file_from_github",
+    "find_record_id_by_name",
 ]
 
 def upload_to_github(filename, repo_name, branch, upload_path, token, max_retries=3):
@@ -191,3 +192,16 @@ def delete_file_from_github(filename, repo_name, branch, upload_path, token, sha
             return
 
         raise Exception(f"❌ GitHub file deletion failed: {delete_resp.status_code} - {delete_resp.text}")
+
+
+def find_record_id_by_name(name, airtable_url, airtable_token):
+    """Return the Airtable record ID with the given Name."""
+    headers = {
+        "Authorization": f"Bearer {airtable_token}",
+        "Content-Type": "application/json",
+    }
+    params = {"filterByFormula": f"{{Name}}='{name}'", "maxRecords": 1}
+    resp = requests.get(airtable_url, headers=headers, params=params)
+    resp.raise_for_status()
+    records = resp.json().get("records", [])
+    return records[0]["id"] if records else None


### PR DESCRIPTION
## Summary
- allow weekly/monthly/yearly utilities to find existing Airtable records via `find_record_id_by_name`
- use the new helper in all TIPS scripts so existing records are updated instead of creating duplicates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431b0cfebc8323bbdbcbe27ccb9f8c