### PR TITLE
Add Dune scripts to trial workflow

### DIFF
--- a/.github/workflows/trial.yml
+++ b/.github/workflows/trial.yml
@@ -16,11 +16,20 @@ jobs:
       fail-fast: false
       matrix:
         script:
-          - "code/daily/BTC ETF Net Flow.py"
           - "code/daily/fetch_gold_prices.py"
           - "code/monthly/fetch_coal_prices.py"
           - "code/monthly/Purchasing Managers' Index (PMI).py"
           - "code/monthly/Business Confidence Index.py"
+          # Dune scripts
+          - "code/daily/Active Addresses.py"
+          - "code/daily/BTC ETF Net Flow.py"
+          - "code/daily/Bitcoin Coin Day Destroyed - Historical Trend.py"
+          - "code/daily/Centralized Stablecoins Market Cap.py"
+          - "code/daily/Miner Revenue.py"
+          - "code/daily/SOPR 3.0.py"
+          - "code/daily/Transaction Count and Active User.py"
+          - "code/daily/US Gov - BTC Balance and USD Value.py"
+          - "code/event_driven/[BTC] UTXO Age Distribution.py"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- add a list of Dune-based scripts to `.github/workflows/trial.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431f0fe42083239e8ee96ee30356e7