### PR TITLE
Fix Coinbase spot history upload path

### DIFF
--- a/code/daily/coinbase_spot_history.py
+++ b/code/daily/coinbase_spot_history.py
@@ -109,7 +109,7 @@ def main():
         df.to_csv(out_file, index=False)
         indicator_name = f"Coinbase {product_id} Spot History"
 
-        github_resp = upload_to_github(filename, GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
+        github_resp = upload_to_github(str(out_file), GITHUB_REPO, BRANCH, UPLOAD_PATH, GITHUB_TOKEN)
         raw_url = github_resp["content"]["raw_url"]
         file_sha = github_resp["content"]["sha"]
 


### PR DESCRIPTION
## Summary
- ensure `coinbase_spot_history` passes the full file path to `upload_to_github`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473d7953708323984a77d61d7165d5