### PR TITLE
Add duplicate removal workflow for Airtable

### DIFF
--- a/.github/workflows/duplicate_cleaner.yml
+++ b/.github/workflows/duplicate_cleaner.yml
@@ -1,0 +1,24 @@
+name: Airtable Duplicate Cleaner
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+
+jobs:
+  clean-duplicates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Remove duplicates
+        run: python code/remove_airtable_duplicates.py

--- a/code/remove_airtable_duplicates.py
+++ b/code/remove_airtable_duplicates.py
@@ -1,0 +1,76 @@
+import os
+import logging
+import requests
+
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = os.getenv("BASE_ID", "appnssPRD9yeYJJe5")
+# List of tables to check for duplicates
+TABLES = [
+    "intraday",
+    "daily",
+    "weekly",
+    "monthly",
+    "quarterly",
+    "yearly",
+    "event_driven",
+]
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def fetch_all_records(airtable_url, headers):
+    records = []
+    offset = None
+    while True:
+        params = {"offset": offset} if offset else {}
+        resp = requests.get(airtable_url, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        records.extend(data.get("records", []))
+        offset = data.get("offset")
+        if not offset:
+            break
+    return records
+
+
+def remove_duplicates_for_table(table):
+    airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{table}"
+    headers = {
+        "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    records = fetch_all_records(airtable_url, headers)
+    grouped = {}
+    for rec in records:
+        name = rec.get("fields", {}).get("Name")
+        if not name:
+            continue
+        grouped.setdefault(name, []).append(rec)
+    deleted_any = False
+    for name, recs in grouped.items():
+        if len(recs) > 1:
+            recs.sort(key=lambda r: r.get("createdTime", ""), reverse=True)
+            for dup in recs[1:]:  # keep the oldest record
+                del_resp = requests.delete(f"{airtable_url}/{dup['id']}", headers=headers)
+                if del_resp.status_code == 200:
+                    logging.info(
+                        f"Deleted duplicate in '{table}': {name} (record {dup['id']})"
+                    )
+                    deleted_any = True
+                else:
+                    logging.error(
+                        f"Failed to delete record {dup['id']} from {table}: {del_resp.text}"
+                    )
+    if not deleted_any:
+        logging.info(f"No duplicates found for table '{table}'")
+
+
+def main():
+    if not AIRTABLE_API_KEY:
+        raise SystemExit("AIRTABLE_API_KEY not set")
+    for table in TABLES:
+        remove_duplicates_for_table(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to remove duplicate Airtable records across tables
- schedule new GitHub Actions workflow every 4 hours to run the cleaner

## Testing
- `pip install --break-system-packages -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68487ede13c88323be172fdd52d619a3