### PR TITLE
Direct Coinbase history to own table

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Historical OHLCV data for **all** online USD spot markets is collected by
 every available pair, then downloads all available daily candles (starting from
 2015) via `/products/{product_id}/candles`. Each dataset is sorted
 chronologically and saved as `<product_id>_fullhistory.csv`. Files are uploaded
-to Airtable as records named "Coinbase `<product_id>` Spot History". Perpetual
-futures such as `COIN50-PERP` are skipped because they require Advanced
-access.
+to the **Coinbase_Price** table as records named "Coinbase `<product_id>` Spot
+History". Perpetual futures such as `COIN50-PERP` are skipped because they
+require Advanced access.
 
 All Coinbase scripts are executed by the intraday and event-driven GitHub Actions
 workflows.

--- a/code/daily/coinbase_spot_history.py
+++ b/code/daily/coinbase_spot_history.py
@@ -15,8 +15,10 @@ API_BASE = "https://api.exchange.coinbase.com"
 
 # === Airtable & GitHub Config ===
 AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
-BASE_ID = "appnssPRD9yeYJJe5"
-TABLE_NAME = "daily"
+# Allow overriding the Airtable base used for price history so these
+# records don't crowd the standard daily table.
+BASE_ID = os.getenv("COINBASE_PRICE_BASE_ID", "appnssPRD9yeYJJe5")
+TABLE_NAME = "Coinbase_Price"
 airtable_url = f"https://api.airtable.com/v0/{BASE_ID}/{TABLE_NAME}"
 
 GITHUB_REPO = "SagarFieldElevate/DatabaseManagement"


### PR DESCRIPTION
## Summary
- store coinbase spot history in a dedicated Airtable table
- document new table in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685081c119c08323a8ec8593b01096d9